### PR TITLE
External client refactor: register only for stub, stub has client map…

### DIFF
--- a/internal/rtm/rtsp/rtsp_connection.go
+++ b/internal/rtm/rtsp/rtsp_connection.go
@@ -8,10 +8,11 @@ import (
 )
 
 type StubConnection struct {
-	conn   pb.MsmControlPlane_SendServer
-	data   pb.Message
-	addCh  chan *pb.Message
-	dataCh chan *base.Response
+	conn    pb.MsmControlPlane_SendServer
+	data    pb.Message
+	addCh   chan *pb.Message
+	dataCh  chan *base.Response
+	clients map[string]string
 }
 
 type RTPProxyConnection struct {

--- a/internal/rtm/rtsp/rtsp_server.go
+++ b/internal/rtm/rtsp/rtsp_server.go
@@ -141,7 +141,7 @@ func (r *RTSP) Send(srv pb.MsmControlPlane_SendServer) error {
 
 		case pb.Event_DELETE:
 			r.logger.Debugf("Received DELETE event: %v", stream)
-			r.OnConnClose(stream)
+			r.OnConnClose(srv, stream)
 
 		case pb.Event_DATA:
 			r.logger.Debugf("Received DATA event: %v", stream)


### PR DESCRIPTION
External clients refactor:
- Register only for stub, stub has client map to keep track of clients that open connection to gateway
- Remove send data-plane IP when add external clients