### PR TITLE
put go mod download before source copy to improve caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 
+RUN go mod download
+
 # Copy the go source
 COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
 COPY pkg/ pkg/
-
-RUN go mod download
 
 ARG TARGETOS TARGETARCH
 


### PR DESCRIPTION
I think this will accelerate builds in general as go mod download won't happen unless modules change