### PR TITLE
Do go mod download before source copy to maximise caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 
+RUN go mod download
+
 # Copy the go source
 COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
 COPY pkg/ pkg/
-
-RUN go mod download
 
 ARG TARGETOS TARGETARCH
 


### PR DESCRIPTION
I think if we do go mod download before we copy the source we'll get better caching for our builds...