### PR TITLE
Refactor

### DIFF
--- a/cmd/grpc_client/main.go
+++ b/cmd/grpc_client/main.go
@@ -40,7 +40,7 @@ func main() {
 	client := pb.NewMsmControlPlaneClient(conn)
 	stream, err := client.Send(context.Background())
 	if err != nil {
-		log.Fatalf("openn stream error %v", err)
+		log.Fatalf("openn stream-mapper error %v", err)
 	}
 
 	ctx := stream.Context()

--- a/cmd/grpc_server/main.go
+++ b/cmd/grpc_server/main.go
@@ -39,10 +39,10 @@ func (s *server) Send(srv pb.MsmControlPlane_SendServer) error {
 		default:
 		}
 
-		// receive data from stream
+		// receive data from stream-mapper
 		stream, err := srv.Recv()
 		if err == io.EOF {
-			// return will close stream from server side
+			// return will close stream-mapper from server side
 			return nil
 		}
 		if err != nil {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"github.com/media-streaming-mesh/msm-cp/internal/stub"
 	node_mapper "github.com/media-streaming-mesh/msm-cp/pkg/node-mapper"
 	"net"
 	"os"
@@ -26,7 +27,6 @@ import (
 	"syscall"
 
 	"github.com/media-streaming-mesh/msm-cp/internal/config"
-	"github.com/media-streaming-mesh/msm-cp/internal/rtm"
 	"github.com/media-streaming-mesh/msm-cp/internal/transport"
 )
 
@@ -34,7 +34,7 @@ import (
 type App struct {
 	cfg *config.Cfg
 
-	rtmImpl    rtm.API
+	stubImpl   stub.StubAPI
 	nodeMapper *node_mapper.NodeMapper
 }
 
@@ -67,7 +67,7 @@ func (a *App) Start() error {
 		transport.UseContext(ctx),
 		transport.UseLogger(logger),
 		transport.UseListener(ln),
-		transport.UseGrpcImpl(a.rtmImpl),
+		transport.UseGrpcImpl(a.stubImpl),
 	}
 
 	var startTransportErr = make(chan error)

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -19,7 +19,7 @@ package core
 import (
 	"context"
 	"fmt"
-	"github.com/media-streaming-mesh/msm-cp/internal/stub"
+	"github.com/media-streaming-mesh/msm-cp/internal/rtm"
 	node_mapper "github.com/media-streaming-mesh/msm-cp/pkg/node-mapper"
 	"net"
 	"os"
@@ -34,7 +34,7 @@ import (
 type App struct {
 	cfg *config.Cfg
 
-	stubImpl   stub.StubAPI
+	rtmImpl    rtm.API
 	nodeMapper *node_mapper.NodeMapper
 }
 
@@ -67,7 +67,7 @@ func (a *App) Start() error {
 		transport.UseContext(ctx),
 		transport.UseLogger(logger),
 		transport.UseListener(ln),
-		transport.UseGrpcImpl(a.stubImpl),
+		transport.UseGrpcImpl(a.rtmImpl),
 	}
 
 	var startTransportErr = make(chan error)

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -19,7 +19,6 @@ package core
 import (
 	"context"
 	"fmt"
-	"github.com/media-streaming-mesh/msm-cp/internal/rtm"
 	node_mapper "github.com/media-streaming-mesh/msm-cp/pkg/node-mapper"
 	"net"
 	"os"
@@ -34,7 +33,7 @@ import (
 type App struct {
 	cfg *config.Cfg
 
-	rtmImpl    rtm.API
+	grpcImpl   API
 	nodeMapper *node_mapper.NodeMapper
 }
 
@@ -67,7 +66,7 @@ func (a *App) Start() error {
 		transport.UseContext(ctx),
 		transport.UseLogger(logger),
 		transport.UseListener(ln),
-		transport.UseGrpcImpl(a.rtmImpl),
+		transport.UseGrpcImpl(a.grpcImpl),
 	}
 
 	var startTransportErr = make(chan error)

--- a/internal/core/protocol.go
+++ b/internal/core/protocol.go
@@ -1,0 +1,124 @@
+package core
+
+import (
+	"fmt"
+	pb "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_cp"
+	"github.com/media-streaming-mesh/msm-cp/internal/config"
+	"github.com/media-streaming-mesh/msm-cp/internal/model"
+	"github.com/media-streaming-mesh/msm-cp/internal/rtm"
+	"github.com/media-streaming-mesh/msm-cp/internal/stub"
+	node_mapper "github.com/media-streaming-mesh/msm-cp/pkg/node-mapper"
+	stream_mapper "github.com/media-streaming-mesh/msm-cp/pkg/stream-mapper"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/peer"
+	"io"
+	"net"
+	"sync"
+)
+
+type API interface {
+	Send(conn pb.MsmControlPlane_SendServer) error
+}
+
+type Protocol struct {
+	cfg         *config.Cfg
+	logger      *logrus.Logger
+	stubHandler *stub.StubHandler
+	rtmImpl     rtm.API
+
+	//TODO: move stream_mapper to msm-nc
+	streamMapper *stream_mapper.StreamMapper
+}
+
+func New(cfg *config.Cfg) *Protocol {
+
+	return &Protocol{
+		cfg:          cfg,
+		logger:       cfg.Logger,
+		stubHandler:  stub.NewStubHandler(cfg),
+		streamMapper: stream_mapper.NewStreamMapper(cfg.Logger, new(sync.Map)),
+		rtmImpl:      rtm.New(cfg),
+	}
+}
+
+func (p *Protocol) log(format string, args ...interface{}) {
+	p.logger.Infof("[GRPC] " + fmt.Sprintf(format, args...))
+}
+
+func (p *Protocol) logError(format string, args ...interface{}) {
+	p.logger.Errorf("[GRPC] " + fmt.Sprintf(format, args...))
+}
+
+func (p *Protocol) Send(conn pb.MsmControlPlane_SendServer) error {
+	var ctx = conn.Context()
+	for {
+		// exit if context is done or continue
+		select {
+		case <-ctx.Done():
+			p.log("received connection done")
+			return nil
+		default:
+		}
+
+		//Process stream data
+		stream, err := conn.Recv()
+		if err == io.EOF {
+			// return will close stream-mapper from server side
+			p.logError("found EOF, exiting")
+			return nil
+		}
+		if err != nil {
+			p.logError("received error %v", err)
+			continue
+		}
+
+		var streamData *model.StreamData
+		
+		switch stream.Event {
+		case pb.Event_REGISTER:
+			p.log("Received REGISTER event: %v", stream)
+			//TODO: Find a cleaner way to map node ip for stub
+			contextPeer, _ := peer.FromContext(ctx)
+			remoteAddr, _, _ := net.SplitHostPort(contextPeer.Addr.String())
+			proxyIp, _ := node_mapper.MapNode(remoteAddr)
+			p.stubHandler.OnRegistration(conn, proxyIp)
+
+		case pb.Event_ADD:
+			p.log("Received ADD event: %v", stream)
+			p.rtmImpl.OnAdd(conn, stream)
+			p.stubHandler.OnAdd(conn, stream)
+		case pb.Event_DELETE:
+			p.log("Received DELETE event: %v", stream)
+			streamData, err = p.rtmImpl.OnDelete(stream)
+			p.stubHandler.OnDelete(conn, stream)
+		case pb.Event_DATA:
+			p.log("Received DATA event: %v", stream)
+			streamData, err = p.rtmImpl.OnData(conn, stream)
+		default:
+		}
+
+		if err != nil {
+			return err
+		}
+
+		//Send data to proxy
+		if streamData != nil {
+			//TODO: Writes logical stream graphs to etcd cluster
+			stubAddress := stub.GetStubAddress(streamData.ClientIp, stream.Remote)
+			p.log("StubAddress %v", stubAddress)
+
+			error := p.streamMapper.ProcessStream(model.StreamData{
+				StubIp:      stubAddress,
+				ServerIp:    streamData.ServerIp,
+				ClientIp:    streamData.ClientIp,
+				ServerPorts: streamData.ServerPorts,
+				ClientPorts: streamData.ClientPorts,
+				StreamState: streamData.StreamState,
+			})
+
+			if error != nil {
+				p.logError("ProcessStream failed %v", error)
+			}
+		}
+	}
+}

--- a/internal/core/wire_gen.go
+++ b/internal/core/wire_gen.go
@@ -16,7 +16,7 @@ import (
 func InitApp() (*App, error) {
 	cfg := config.New()
 	nodeMapper := &node_mapper.NodeMapper{}
-	nodeMapper.InitializeNodeMapper()
+	nodeMapper.InitializeNodeMapper(cfg)
 	protocol := rtm.New(cfg)
 
 	app := &App{

--- a/internal/core/wire_gen.go
+++ b/internal/core/wire_gen.go
@@ -7,7 +7,7 @@ package core
 
 import (
 	"github.com/media-streaming-mesh/msm-cp/internal/config"
-	"github.com/media-streaming-mesh/msm-cp/internal/rtm"
+	"github.com/media-streaming-mesh/msm-cp/internal/stub"
 	node_mapper "github.com/media-streaming-mesh/msm-cp/pkg/node-mapper"
 )
 
@@ -15,13 +15,14 @@ import (
 
 func InitApp() (*App, error) {
 	cfg := config.New()
-	protocol := rtm.New(cfg)
 	nodeMapper := &node_mapper.NodeMapper{}
 	nodeMapper.InitializeNodeMapper()
 
+	stubHandler := stub.NewStubHandler(cfg)
+
 	app := &App{
 		cfg:     cfg,
-		rtmImpl: protocol,
+		stubImpl: stubHandler,
 		nodeMapper: nodeMapper,
 	}
 	return app, nil

--- a/internal/core/wire_gen.go
+++ b/internal/core/wire_gen.go
@@ -7,7 +7,7 @@ package core
 
 import (
 	"github.com/media-streaming-mesh/msm-cp/internal/config"
-	"github.com/media-streaming-mesh/msm-cp/internal/stub"
+	"github.com/media-streaming-mesh/msm-cp/internal/rtm"
 	node_mapper "github.com/media-streaming-mesh/msm-cp/pkg/node-mapper"
 )
 
@@ -17,12 +17,11 @@ func InitApp() (*App, error) {
 	cfg := config.New()
 	nodeMapper := &node_mapper.NodeMapper{}
 	nodeMapper.InitializeNodeMapper()
-
-	stubHandler := stub.NewStubHandler(cfg)
+	protocol := rtm.New(cfg)
 
 	app := &App{
 		cfg:     cfg,
-		stubImpl: stubHandler,
+		rtmImpl: protocol,
 		nodeMapper: nodeMapper,
 	}
 	return app, nil

--- a/internal/core/wire_gen.go
+++ b/internal/core/wire_gen.go
@@ -7,7 +7,6 @@ package core
 
 import (
 	"github.com/media-streaming-mesh/msm-cp/internal/config"
-	"github.com/media-streaming-mesh/msm-cp/internal/rtm"
 	node_mapper "github.com/media-streaming-mesh/msm-cp/pkg/node-mapper"
 )
 
@@ -17,11 +16,11 @@ func InitApp() (*App, error) {
 	cfg := config.New()
 	nodeMapper := &node_mapper.NodeMapper{}
 	nodeMapper.InitializeNodeMapper(cfg)
-	protocol := rtm.New(cfg)
+	grpcImpl := New(cfg)
 
 	app := &App{
 		cfg:     cfg,
-		rtmImpl: protocol,
+		grpcImpl: grpcImpl,
 		nodeMapper: nodeMapper,
 	}
 	return app, nil

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,57 +1,5 @@
 package model
 
-import (
-	"github.com/aler9/gortsplib/pkg/base"
-	pb "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_cp"
-	"sync"
-)
-
-// ============================================= Stub =============================================
-var (
-	StubMap *sync.Map
-)
-
-type StubConnection struct {
-	Address     string
-	Conn        pb.MsmControlPlane_SendServer
-	Data        pb.Message
-	SendToAddCh bool
-	AddCh       chan *pb.Message
-	DataCh      chan *base.Response
-	Clients     map[string]Client
-}
-
-func NewStubConnection(address string, conn pb.MsmControlPlane_SendServer) *StubConnection {
-	return &StubConnection{
-		Address: address,
-		Conn:    conn,
-		AddCh:   make(chan *pb.Message, 1),
-		DataCh:  make(chan *base.Response, 1),
-		Clients: make(map[string]Client),
-	}
-}
-
-// ============================================= StreamId =============================================
-var streamId StreamId
-
-// Stream id type uint32 auto increment
-type StreamId struct {
-	sync.Mutex
-	id uint32
-}
-
-func (si *StreamId) ID() (id uint32) {
-	si.Lock()
-	defer si.Unlock()
-	id = si.id
-	si.id++
-	return
-}
-
-func GetStreamID() uint32 {
-	return streamId.ID()
-}
-
 //============================================= Stream =============================================
 
 type Stream struct {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,0 +1,90 @@
+package model
+
+import (
+	"github.com/aler9/gortsplib/pkg/base"
+	pb "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_cp"
+	"sync"
+)
+
+// ============================================= Stub =============================================
+var (
+	StubMap *sync.Map
+)
+
+type StubConnection struct {
+	Address     string
+	Conn        pb.MsmControlPlane_SendServer
+	Data        pb.Message
+	SendToAddCh bool
+	AddCh       chan *pb.Message
+	DataCh      chan *base.Response
+	Clients     map[string]string
+}
+
+func NewStubConnection(address string, conn pb.MsmControlPlane_SendServer) *StubConnection {
+	return &StubConnection{
+		Address: address,
+		Conn:    conn,
+		AddCh:   make(chan *pb.Message, 1),
+		DataCh:  make(chan *base.Response, 1),
+		Clients: make(map[string]string),
+	}
+}
+
+// ============================================= StreamId =============================================
+var streamId StreamId
+
+// Stream id type uint32 auto increment
+type StreamId struct {
+	sync.Mutex
+	id uint32
+}
+
+func (si *StreamId) ID() (id uint32) {
+	si.Lock()
+	defer si.Unlock()
+	id = si.id
+	si.id++
+	return
+}
+
+func GetStreamID() uint32 {
+	return streamId.ID()
+}
+
+//============================================= Stream =============================================
+
+type Stream struct {
+	StreamId uint32
+	ProxyMap map[string]Proxy
+}
+
+type StreamData struct {
+	StubIp      string
+	ServerIp    string
+	ClientIp    string
+	ServerPorts []uint32
+	ClientPorts []uint32
+	StreamState StreamState
+}
+
+type StreamState int
+
+const (
+	Create   StreamState = 0
+	Play                 = 1
+	Teardown             = 2
+)
+
+// ============================================= Proxy =============================================
+type Proxy struct {
+	ProxyIp     string
+	StreamState StreamState
+	Clients     []Client
+}
+
+type Client struct {
+	ClientId string
+	ClientIp string
+	Port     uint32
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -18,7 +18,7 @@ type StubConnection struct {
 	SendToAddCh bool
 	AddCh       chan *pb.Message
 	DataCh      chan *base.Response
-	Clients     map[string]string
+	Clients     map[string]Client
 }
 
 func NewStubConnection(address string, conn pb.MsmControlPlane_SendServer) *StubConnection {
@@ -27,7 +27,7 @@ func NewStubConnection(address string, conn pb.MsmControlPlane_SendServer) *Stub
 		Conn:    conn,
 		AddCh:   make(chan *pb.Message, 1),
 		DataCh:  make(chan *base.Response, 1),
-		Clients: make(map[string]string),
+		Clients: make(map[string]Client),
 	}
 }
 

--- a/internal/rtm/protocol.go
+++ b/internal/rtm/protocol.go
@@ -18,32 +18,23 @@ package rtm
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	pb "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_cp"
 	"github.com/media-streaming-mesh/msm-cp/internal/config"
 	"github.com/media-streaming-mesh/msm-cp/internal/model"
 	"github.com/media-streaming-mesh/msm-cp/internal/rtm/rtsp"
-	"github.com/media-streaming-mesh/msm-cp/internal/stub"
-	stream_mapper "github.com/media-streaming-mesh/msm-cp/pkg/stream-mapper"
-	"github.com/sirupsen/logrus"
-	"io"
-	"sync"
 )
 
 // API provides external access to
 type API interface {
-	Send(conn pb.MsmControlPlane_SendServer) error
+	OnAdd(conn pb.MsmControlPlane_SendServer, stream *pb.Message)
+	OnDelete(stream *pb.Message) (*model.StreamData, error)
+	OnData(conn pb.MsmControlPlane_SendServer, stream *pb.Message) (*model.StreamData, error)
 }
 
 // Protocol holds the rtm protocol specific data structures
 type Protocol struct {
-	cfg         *config.Cfg
-	logger      *logrus.Logger
-	stubHandler *stub.StubHandler
-	//TODO: move stream_mapper to msm-nc
-	streamMapper *stream_mapper.StreamMapper
-
-	//rtm protocol
+	cfg  *config.Cfg
 	rtsp *rtsp.RTSP
 }
 
@@ -57,91 +48,36 @@ func New(cfg *config.Cfg) *Protocol {
 	}
 
 	return &Protocol{
-		cfg:          cfg,
-		logger:       cfg.Logger,
-		stubHandler:  stub.NewStubHandler(cfg),
-		streamMapper: stream_mapper.NewStreamMapper(cfg.Logger, new(sync.Map)),
-		rtsp:         rtsp.NewRTSP(rtspOpts...),
+		cfg:  cfg,
+		rtsp: rtsp.NewRTSP(rtspOpts...),
 	}
 }
 
-func (p *Protocol) log(format string, args ...interface{}) {
-	p.logger.Infof("[RTM] " + fmt.Sprintf(format, args...))
-}
-
-func (p *Protocol) logError(format string, args ...interface{}) {
-	p.logger.Errorf("[RTM] " + fmt.Sprintf(format, args...))
-}
-
-func (p *Protocol) Send(conn pb.MsmControlPlane_SendServer) error {
-	var ctx = conn.Context()
-	for {
-		// exit if context is done or continue
-		select {
-		case <-ctx.Done():
-			p.log("received connection done")
-			return nil
-		default:
-		}
-
-		//Process stream data
-		stream, err := conn.Recv()
-		if err == io.EOF {
-			// return will close stream-mapper from server side
-			p.logError("found EOF, exiting")
-			return nil
-		}
-		if err != nil {
-			p.logError("received error %v", err)
-			continue
-		}
-
-		switch stream.Event {
-		case pb.Event_REGISTER:
-			p.log("Received REGISTER event: %v", stream)
-		case pb.Event_ADD:
-			p.log("Received ADD event: %v", stream)
-		case pb.Event_DELETE:
-			p.log("Received DELETE event: %v", stream)
-		case pb.Event_DATA:
-			p.log("Received DATA event: %v", stream)
-		default:
-		}
-
-		//Handle rtm request
-		var streamData *model.StreamData
-		proto := p.cfg.Protocol
-		switch proto {
-		case "rtsp":
-			streamData, err = p.rtsp.Send(conn, stream)
-		default:
-		}
-		if err != nil {
-			return err
-		}
-
-		//Handle stub request
-		p.stubHandler.Send(conn, stream)
-
-		//Send data to proxy
-		if streamData != nil {
-			//TODO: Writes logical stream graphs to etcd cluster
-			stubAddress := stub.GetStubAddress(streamData.ClientIp, stream.Remote)
-			p.log("StubAddress %v", stubAddress)
-
-			error := p.streamMapper.ProcessStream(model.StreamData{
-				StubIp:      stubAddress,
-				ServerIp:    streamData.ServerIp,
-				ClientIp:    streamData.ClientIp,
-				ServerPorts: streamData.ServerPorts,
-				ClientPorts: streamData.ClientPorts,
-				StreamState: streamData.StreamState,
-			})
-
-			if error != nil {
-				p.logError("ProcessStream failed %v", error)
-			}
-
-		}
+func (p *Protocol) OnAdd(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
+	proto := p.cfg.Protocol
+	switch proto {
+	case "rtsp":
+		p.rtsp.OnAdd(conn, stream)
+	default:
 	}
+}
+
+func (p *Protocol) OnDelete(stream *pb.Message) (*model.StreamData, error) {
+	proto := p.cfg.Protocol
+	switch proto {
+	case "rtsp":
+		return p.rtsp.OnDelete(stream)
+	default:
+	}
+	return nil, errors.New("Failed to get rtm protocol type from config")
+}
+
+func (p *Protocol) OnData(conn pb.MsmControlPlane_SendServer, stream *pb.Message) (*model.StreamData, error) {
+	proto := p.cfg.Protocol
+	switch proto {
+	case "rtsp":
+		return p.rtsp.OnData(conn, stream)
+	default:
+	}
+	return nil, errors.New("Failed to get rtm protocol type from config")
 }

--- a/internal/rtm/rtsp/handle_request.go
+++ b/internal/rtm/rtsp/handle_request.go
@@ -32,7 +32,7 @@ func (r *RTSP) handleRequest(req *base.Request, s *pb.Message) (*base.Response, 
 	var cSeq base.HeaderValue
 
 	if cSeq, ok = req.Header["CSeq"]; !ok || len(cSeq) != 1 {
-		r.logger.Error("CSeq missing")
+		r.logError("CSeq missing")
 
 		return &base.Response{
 			StatusCode: base.StatusBadRequest,
@@ -87,11 +87,11 @@ func (r *RTSP) handleRequest(req *base.Request, s *pb.Message) (*base.Response, 
 	}
 
 	if err != nil {
-		r.logger.Debugf("error processing CP message")
+		r.logError("error processing CP message")
 		return nil, err
 	} else {
 		// reflect back the cSeq
-		r.logger.Debugf("cseq = %v", cSeq)
+		r.log("cseq = %v", cSeq)
 		res.Header["CSeq"] = cSeq
 		return res, nil
 	}

--- a/internal/rtm/rtsp/handle_request.go
+++ b/internal/rtm/rtsp/handle_request.go
@@ -21,7 +21,7 @@ import (
 	"github.com/aler9/gortsplib/pkg/base"
 	"github.com/aler9/gortsplib/pkg/liberrors"
 	pb "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_cp"
-	"github.com/media-streaming-mesh/msm-cp/internal/model"
+	"github.com/media-streaming-mesh/msm-cp/internal/stub"
 )
 
 func (r *RTSP) handleRequest(req *base.Request, s *pb.Message) (*base.Response, error) {
@@ -99,12 +99,12 @@ func (r *RTSP) handleRequest(req *base.Request, s *pb.Message) (*base.Response, 
 
 func (r *RTSP) handleResponse(res *base.Response, s *pb.Message) error {
 	key := getRemoteIPv4Address(s.Remote)
-	stubConn, ok := model.StubMap.Load(key)
+	stubConn, ok := stub.StubMap.Load(key)
 	if !ok {
 		return errors.New("Can't find stub connection")
 	}
 
-	stubConn.(*model.StubConnection).DataCh <- res
+	stubConn.(*stub.StubConnection).DataCh <- res
 	return nil
 }
 

--- a/internal/rtm/rtsp/handle_request.go
+++ b/internal/rtm/rtsp/handle_request.go
@@ -18,10 +18,10 @@ package rtsp
 
 import (
 	"errors"
-
 	"github.com/aler9/gortsplib/pkg/base"
 	"github.com/aler9/gortsplib/pkg/liberrors"
 	pb "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_cp"
+	"github.com/media-streaming-mesh/msm-cp/internal/model"
 )
 
 func (r *RTSP) handleRequest(req *base.Request, s *pb.Message) (*base.Response, error) {
@@ -97,16 +97,13 @@ func (r *RTSP) handleRequest(req *base.Request, s *pb.Message) (*base.Response, 
 }
 
 func (r *RTSP) handleResponse(res *base.Response, s *pb.Message) error {
-
 	key := getRemoteIPv4Address(s.Remote)
-	stubConn, ok := r.stubConn.Load(key)
+	stubConn, ok := model.StubMap.Load(key)
 	if !ok {
-		r.logger.Errorf("This is just bad")
-		return errors.New("shit2")
+		return errors.New("Can't find stub connection")
 	}
 
-	stubConn.(*StubConnection).dataCh <- res
-
+	stubConn.(*model.StubConnection).DataCh <- res
 	return nil
 }
 

--- a/internal/rtm/rtsp/rtsp_connection.go
+++ b/internal/rtm/rtsp/rtsp_connection.go
@@ -2,18 +2,9 @@ package rtsp
 
 import (
 	"github.com/aler9/gortsplib/pkg/base"
-	pb "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_cp"
 	dp "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_dp"
 	"github.com/sirupsen/logrus"
 )
-
-type StubConnection struct {
-	conn    pb.MsmControlPlane_SendServer
-	data    pb.Message
-	addCh   chan *pb.Message
-	dataCh  chan *base.Response
-	clients map[string]string
-}
 
 type RTPProxyConnection struct {
 	conn       dp.MsmDataPlaneClient

--- a/internal/rtm/rtsp/rtsp_handler.go
+++ b/internal/rtm/rtsp/rtsp_handler.go
@@ -268,6 +268,7 @@ func (r *RTSP) connectToRemote(req *base.Request, s *pb.Message) (*base.Response
 		// Waiting for server pod response with local/remote ports
 		// CP will receive Event_ADD and send value to addCh to unblock channel
 		<-stubConn.(*model.StubConnection).AddCh
+		stubConn.(*model.StubConnection).SendToAddCh = false
 	} else {
 		r.logger.Debugf("Remote endpoint RTSP connection open")
 	}
@@ -443,7 +444,6 @@ func (r *RTSP) getRemoteRTSPConnection(s *pb.Message) (*RTSPConnection, error) {
 }
 
 func (r *RTSP) getClientCount(serverEp string) int {
-	r.logger.Debugf("Get client count %v", r.clientMap)
 	count := 0
 	for _, v := range r.clientMap {
 		if v.serverIp == serverEp {

--- a/internal/rtm/rtsp/rtsp_server.go
+++ b/internal/rtm/rtsp/rtsp_server.go
@@ -20,20 +20,15 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
-	"io"
+	"github.com/media-streaming-mesh/msm-cp/internal/model"
 	"strings"
 	"sync"
-
-	"github.com/media-streaming-mesh/msm-cp/internal/transport"
-	node_mapper "github.com/media-streaming-mesh/msm-cp/pkg/node-mapper"
 
 	"github.com/aler9/gortsplib/pkg/base"
 	"github.com/sirupsen/logrus"
 
 	pb "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_cp"
-	pb_dp "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_dp"
 	msm_url "github.com/media-streaming-mesh/msm-cp/pkg/url-routing/handler"
 )
 
@@ -41,26 +36,14 @@ type RTSP struct {
 	urlHandler *msm_url.UrlHandler
 	logger     *logrus.Logger
 	methods    []base.Method
-	stubConn   *sync.Map
 	rtspConn   *sync.Map
-	rtspStream *sync.Map
-}
-
-type RTSPStream struct {
-	streamID uint32
-	proxyMap map[string]Proxy
-}
-
-type Proxy struct {
-	proxyIP     string
-	streamState RTSPConnectionState
-	clients     []Client
+	clientMap  map[string]Client
 }
 
 type Client struct {
-	clientIP          string
-	port              uint32
-	rtspConnectionKey string
+	clientIp    string
+	clientPorts []uint32
+	serverIp    string
 }
 
 // Option configures NewRTSP
@@ -111,369 +94,150 @@ func NewRTSP(opts ...Option) *RTSP {
 		urlHandler: uHandler,
 		logger:     cfg.Logger,
 		methods:    cfg.SupportedMethods,
-		stubConn:   new(sync.Map),
 		rtspConn:   new(sync.Map),
-		rtspStream: new(sync.Map),
+		clientMap:  make(map[string]Client),
 	}
 
 }
 
-func (r *RTSP) Send(srv pb.MsmControlPlane_SendServer) error {
-	var ctx = srv.Context()
+// called when a connection is opened.
+func (r *RTSP) OnConnOpen(stream *pb.Message) {
+	// create a new RTSP connection and store it
+	rc := newRTSPConnection(r.logger)
+	rc.author = stream.Remote
+
+	key := getRTSPConnectionKey(stream.Local, stream.Remote)
+	r.rtspConn.Store(key, rc)
+	r.logger.Infof("RTSP connection key %v", key)
+	r.logger.Infof("RTSP connection opened from client %s", stream.Remote)
+}
+
+// called when a connection is close.
+func (r *RTSP) OnConnClose(stream *pb.Message) *model.StreamData {
+	// Get stream data
+	streamData := r.getStreamData(stream, model.Teardown)
+	// Find RTSP connection and delete it
+	key := getRTSPConnectionKey(stream.Local, stream.Remote)
+	r.rtspConn.Delete(key)
+
+	//Delete client from client map
+	connectionKey := getRTSPConnectionKey(stream.Local, stream.Remote)
+	delete(r.clientMap, connectionKey)
+
+	r.logger.Infof("RTSP connection closed from client %s", stream.Remote)
+
+	return streamData
+}
+
+func (r *RTSP) OnExternalClientConnOpen(stream *pb.Message, stubData pb.Message) {
+	// create a new RTSP connection and store it
+	rc := newRTSPConnection(r.logger)
+	rc.author = stream.Remote
+	rc.targetLocal = stubData.Local
+	rc.targetRemote = stubData.Remote
+
+	key := getRTSPConnectionKey(stream.Local, stream.Remote)
+	r.rtspConn.Store(key, rc)
+	r.logger.Infof("RTSP connection key %v", key)
+	r.logger.Infof("RTSP connection opened from external client %s", stream.Remote)
+}
+
+func (r *RTSP) OnData(conn pb.MsmControlPlane_SendServer, stream *pb.Message) *model.StreamData {
+	//Read stream data
+	var streamData *model.StreamData
 	var data = bytes.NewBuffer(make([]byte, 0, 4096))
+	reqReader := bufio.NewReader(strings.NewReader(stream.Data))
+	resReader := bufio.NewReader(strings.NewReader(stream.Data))
 
-	for {
+	req := &base.Request{}
+	res := &base.Response{}
 
-		// exit if context is done or continue
-		select {
-		case <-ctx.Done():
-			r.logger.Debugf("reveiced connection done")
-			return ctx.Err()
-		default:
+	errReq := req.Read(reqReader)
+	errRes := res.Read(resReader)
+
+	if errReq != nil && errRes != nil {
+		r.logger.Errorf("request error=%s", errReq)
+		r.logger.Errorf("response error=%s", errRes)
+	} else if errReq == nil {
+		//Get client ports
+		clientPorts := getClientPorts(req.Header["Transport"])
+		if len(clientPorts) != 0 {
+			connectionKey := getRTSPConnectionKey(stream.Local, stream.Remote)
+			r.clientMap[connectionKey] = Client{
+				clientPorts: clientPorts,
+			}
 		}
 
-		// receive data from stream
-		stream, err := srv.Recv()
-		if err == io.EOF {
-			// return will close stream from server side
-			r.logger.Info("found EOF, exiting")
+		if req.Method == base.Teardown {
+			streamData = r.getStreamData(stream, model.Teardown)
+		}
+		// received a client-side request
+		pbMsg, err := r.handleRequest(req, stream)
+		if err != nil {
+			r.logger.Errorf("handle request error=%s", err)
+		}
+		pbMsg.Write(data)
+		pbRes := &pb.Message{
+			Event:  stream.Event,
+			Local:  stream.Local,
+			Remote: stream.Remote,
+			Data:   fmt.Sprintf("%s", data),
+		}
+
+		r.logger.Debugf("response to client is %v", pbRes)
+
+		//Send response back to client
+		err = conn.Send(pbRes)
+		if err != nil {
+			r.logger.Errorf("could not send response, error: %v", err)
 			return nil
 		}
-		if err != nil {
-			r.logger.Errorf("received error %v", err)
-			continue
+
+		//Get stream data
+		if req.Method == base.Setup {
+			streamData = r.getStreamData(stream, model.Create)
+		}
+		if req.Method == base.Play {
+			streamData = r.getStreamData(stream, model.Play)
 		}
 
-		switch stream.Event {
-		case pb.Event_REGISTER:
-			r.logger.Debugf("Received REGISTER event: %v", stream)
-			r.OnRegistration(srv)
-
-		case pb.Event_ADD:
-			r.logger.Debugf("Received ADD event: %v", stream)
-			r.OnConnOpen(srv, stream)
-
-		case pb.Event_DELETE:
-			r.logger.Debugf("Received DELETE event: %v", stream)
-			r.OnConnClose(srv, stream)
-
-		case pb.Event_DATA:
-			r.logger.Debugf("Received DATA event: %v", stream)
-
-			reqReader := bufio.NewReader(strings.NewReader(stream.Data))
-			resReader := bufio.NewReader(strings.NewReader(stream.Data))
-
-			req := &base.Request{}
-			res := &base.Response{}
-
-			errReq := req.Read(reqReader)
-			errRes := res.Read(resReader)
-
-			if errReq != nil && errRes != nil {
-				return err
-			} else if errReq == nil {
-				clientPorts := getClientPorts(req.Header["Transport"])
-				// received a client-side request
-				pbMsg, err := r.handleRequest(req, stream)
-				if err != nil {
-					r.logger.Errorf("incoming request error=%s", err)
-					return err
-				}
-				pbMsg.Write(data)
-				pbRes := &pb.Message{
-					Event:  stream.Event,
-					Local:  stream.Local,
-					Remote: stream.Remote,
-					Data:   fmt.Sprintf("%s", data),
-				}
-
-				r.logger.Debugf("response to client is %v", pbRes)
-
-				//Send response back to client
-				if err := srv.Send(pbRes); err != nil {
-					r.logger.Errorf("could not send response, error: %v", err)
-				} else {
-					//Update data to proxy
-					if req.Method == base.Setup || req.Method == base.Play {
-						if err := r.SendProxyData(stream, clientPorts); err != nil {
-							r.logger.Errorf("Could not send proxy data %v", err)
-						}
-					}
-				}
-			} else if errRes == nil {
-				// received a server-side response
-				err := r.handleResponse(res, stream)
-				if err != nil {
-					r.logger.Errorf("incoming request error=%s", err)
-					return err
-				}
-			}
-
-		default:
+	} else if errRes == nil {
+		// received a server-side response
+		err := r.handleResponse(res, stream)
+		if err != nil {
+			r.logger.Errorf("incoming request error=%s", err)
 		}
 	}
+	return streamData
 }
 
-func (r *RTSP) SendProxyData(s *pb.Message, clientPorts []uint32) error {
-
-	var serverProxyIP string
-	var clientProxyIP string
-	var serverDpGrpcClient transport.Client
-	var clientDpGrpcClient transport.Client
-
-	// 1. Get client/remote RTSP connection
-	rc, err := r.getClientRTSPConnection(s)
+func (r *RTSP) getStreamData(stream *pb.Message, streamState model.StreamState) *model.StreamData {
+	rc, err := r.getClientRTSPConnection(stream)
 	if err != nil {
-		return err
+		return nil
 	}
 
-	s_rc, err := r.getRemoteRTSPConnection(s)
+	s_rc, err := r.getRemoteRTSPConnection(stream)
 	if err != nil {
-		return err
+		return nil
 	}
 
-	// 2. Get client/remote endpoint
-	clientEp := getRemoteIPv4Address(s.Remote)
-	serverEp := getRemoteIPv4Address(rc.targetRemote)
+	serverAddress := getRemoteIPv4Address(rc.targetRemote)
+	clientAddress := getRemoteIPv4Address(stream.Remote)
+	serverPorts := getServerPorts(s_rc.response[Setup].Header["Transport"])
+	client := r.clientMap[getRTSPConnectionKey(stream.Local, stream.Remote)]
 
-	r.logger.Debugf("client EP is %v", clientEp)
-	r.logger.Debugf("server EP is %v", serverEp)
+	r.logger.Debugf("server address/ports %v %v", serverAddress, serverPorts)
+	r.logger.Debugf("client address/ports %v %v", clientAddress, client.clientPorts)
 
-	endpoint := r.getStubAddress(s.Remote)
-	if endpoint == "" {
-		endpoint = clientEp
-	}
-	//Check if client/server on same node
-	isOnSameNode := node_mapper.IsOnSameNode(endpoint, serverEp)
-	r.logger.Debugf("server %v and endpoint %v - same node is %v", serverEp, endpoint, isOnSameNode)
-
-	clientProxyIP, err = node_mapper.MapNode(clientEp)
-	if err != nil {
-		nodeEp := getRemoteIPv4Address(s.Local)
-
-		r.logger.Debugf("node EP is %v", nodeEp)
-
-		clientProxyIP, err = node_mapper.MapNode(nodeEp)
-	}
-	r.logger.Debugf("client msm-proxy ip %v", clientProxyIP)
-
-	if err != nil {
-		return err
+	streamData := model.StreamData{
+		"",
+		serverAddress,
+		clientAddress,
+		serverPorts,
+		client.clientPorts,
+		streamState,
 	}
 
-	if !isOnSameNode {
-		serverProxyIP, err = node_mapper.MapNode(serverEp)
-		if err != nil {
-			return err
-		}
-		r.logger.Debugf("server msm-proxy ip %v", serverProxyIP)
-	}
-
-	//TODO: create GRPC connection to server once
-	clientGrpcClient, err := transport.SetupClient(clientProxyIP)
-	if err != nil {
-		r.logger.Debugf("Failed to setup GRPC client, error %s\n", err)
-	}
-	clientDpGrpcClient = transport.Client{
-		r.logger,
-		clientGrpcClient,
-	}
-
-	if !isOnSameNode {
-		serverGrpcClient, err := transport.SetupClient(serverProxyIP)
-		if err != nil {
-			r.logger.Debugf("Failed to setup GRPC client, error %s\n", err)
-		}
-		serverDpGrpcClient = transport.Client{
-			r.logger,
-			serverGrpcClient,
-		}
-	}
-
-	if rc.state == Setup {
-		var rtspStream RTSPStream
-
-		// // 3. Get client/remote ports
-		// these need to be assigned by controller - not stub or app
-		serverPorts := getServerPorts(s_rc.response[Setup].Header["Transport"])
-		rtspConnectionKey := getRTSPConnectionKey(s.Local, s.Remote)
-
-		if len(serverPorts) == 0 || len(clientPorts) == 0 {
-			r.logger.Errorf("Server ports or client ports is nil")
-		}
-
-		r.logger.Debugf("server endpoint/ports %v %v", serverEp, serverPorts)
-		r.logger.Debugf("client endpoint/ports %v %v", clientEp, clientPorts)
-		r.logger.Debugf("RTSP connection key %v", rtspConnectionKey)
-
-		data, _ := r.rtspStream.Load(serverEp)
-		if data == nil {
-			streamId := transport.GetStreamID()
-			r.logger.Debugf("stream ID %v", streamId)
-
-			// create the RTSP stream
-			rtspStream = RTSPStream{
-				streamID: streamId,
-				proxyMap: make(map[string]Proxy),
-			}
-
-			if isOnSameNode {
-				// add the stream to the proxy
-				stream, result := clientDpGrpcClient.CreateStream(streamId, pb_dp.Encap_RTP_UDP, serverEp, serverPorts[0])
-				r.logger.Debugf("Create stream %v result %v", stream, *result)
-
-			} else {
-				// add the stream to the server proxy
-				stream, result := serverDpGrpcClient.CreateStream(streamId, pb_dp.Encap_RTP_UDP, serverEp, serverPorts[0])
-				r.logger.Debugf("Create server stream %v result %v", stream, *result)
-
-				// add the stream to the client proxy
-				stream, result = clientDpGrpcClient.CreateStream(streamId, pb_dp.Encap_RTP_UDP, serverProxyIP, serverPorts[0])
-				r.logger.Debugf("Create client stream %v result %v", stream, *result)
-
-				// add the server proxy to the proxy map
-				rtspStream.proxyMap[serverProxyIP] = Proxy{
-					proxyIP:     serverProxyIP,
-					streamState: Create,
-				}
-			}
-
-			// add the client proxy to the proxy map
-			rtspStream.proxyMap[clientProxyIP] = Proxy{
-				proxyIP:     clientProxyIP,
-				streamState: Create,
-			}
-
-			// now store the RTSP stream
-			r.rtspStream.Store(serverEp, rtspStream)
-
-		} else {
-			rtspStream = data.(RTSPStream)
-			if _, exists := rtspStream.proxyMap[clientProxyIP]; !exists {
-				// add the stream to the client proxy
-				stream, result := clientDpGrpcClient.CreateStream(rtspStream.streamID, pb_dp.Encap_RTP_UDP, serverProxyIP, serverPorts[0])
-				r.logger.Debugf("Create client stream %v result %v", stream, *result)
-
-				// add the client proxy to the proxy map
-				rtspStream.proxyMap[clientProxyIP] = Proxy{
-					proxyIP:     clientProxyIP,
-					streamState: Create,
-				}
-			}
-		}
-		clientProxy := rtspStream.proxyMap[clientProxyIP]
-		r.logger.Debugf("Client proxy SETUP %v proxy clients %v", clientProxy, len(clientProxy.clients))
-
-		if !isOnSameNode && clientProxy.streamState < Setup {
-			endpoint, result := serverDpGrpcClient.CreateEndpoint(rtspStream.streamID, pb_dp.Encap_RTP_UDP, clientProxyIP, 8050)
-			clientProxy.streamState = Create
-			r.logger.Debugf("Created proxy ep %v result %v", endpoint, *result)
-		}
-
-		endpoint, result := clientDpGrpcClient.CreateEndpoint(rtspStream.streamID, pb_dp.Encap_RTP_UDP, clientEp, clientPorts[0])
-		clientProxy.clients = append(clientProxy.clients, Client{
-			clientIP:          clientEp,
-			port:              clientPorts[0],
-			rtspConnectionKey: rtspConnectionKey,
-		})
-		rtspStream.proxyMap[clientProxyIP] = Proxy{
-			proxyIP:     clientProxyIP,
-			streamState: clientProxy.streamState,
-			clients:     clientProxy.clients,
-		}
-		r.logger.Debugf("Created ep %v result %v", endpoint, *result)
-
-	}
-
-	if rc.state == Play {
-		data, _ := r.rtspStream.Load(serverEp)
-		if data == nil {
-			return errors.New("Can't find stream")
-		}
-
-		rtspStream := data.(RTSPStream)
-		rtspConnectionKey := getRTSPConnectionKey(s.Local, s.Remote)
-		clientProxy, exists := rtspStream.proxyMap[clientProxyIP]
-		if !exists {
-			return errors.New("Can't find client proxy")
-		}
-		r.logger.Debugf("Client proxy PLAY %v proxy clients %v", clientProxy, len(clientProxy.clients))
-		for _, c := range clientProxy.clients {
-			if c.clientIP == clientEp && c.rtspConnectionKey == rtspConnectionKey {
-				endpoint, result := clientDpGrpcClient.UpdateEndpoint(rtspStream.streamID, clientEp, c.port)
-				r.logger.Debugf("Update ep %v %v", endpoint, result)
-
-				if !isOnSameNode && clientProxy.streamState < Setup {
-					endpoint2, result := serverDpGrpcClient.UpdateEndpoint(rtspStream.streamID, clientProxyIP, 8050)
-					rtspStream.proxyMap[clientProxyIP] = Proxy{
-						proxyIP:     clientProxy.proxyIP,
-						streamState: Play,
-						clients:     clientProxy.clients,
-					}
-					r.logger.Debugf("Update proxy ep %v %v", endpoint2, result)
-				}
-				break
-			}
-		}
-	}
-
-	if rc.state == Teardown {
-		data, _ := r.rtspStream.Load(serverEp)
-		if data == nil {
-			return errors.New("Can't find stream id")
-		}
-
-		rtspStream := data.(RTSPStream)
-		rtspConnectionKey := getRTSPConnectionKey(s.Local, s.Remote)
-		clientProxy, exists := rtspStream.proxyMap[clientProxyIP]
-		if !exists {
-			return errors.New("Can't find client proxy")
-		}
-		r.logger.Debugf("Client proxy TEARDOWN %v proxy clients %v total clients %v", clientProxy, len(clientProxy.clients), r.getClientCount(serverEp))
-
-		for i, c := range clientProxy.clients {
-			if c.clientIP == clientEp && c.rtspConnectionKey == rtspConnectionKey {
-				endpoint, result := clientDpGrpcClient.DeleteEndpoint(rtspStream.streamID, clientEp, c.port)
-				r.logger.Debugf("Delete ep %v %v", endpoint, result)
-				clientProxy.clients = append(clientProxy.clients[:i], clientProxy.clients[i+1:]...)
-				break
-			}
-		}
-
-		rtspStream.proxyMap[clientProxyIP] = Proxy{
-			proxyIP:     clientProxy.proxyIP,
-			streamState: clientProxy.streamState,
-			clients:     clientProxy.clients,
-		}
-
-		//End proxy-proxy connection
-		if !isOnSameNode && clientProxy.streamState < Teardown && len(clientProxy.clients) == 0 {
-			endpoint2, result := serverDpGrpcClient.DeleteEndpoint(rtspStream.streamID, clientProxyIP, 8050)
-			delete(rtspStream.proxyMap, clientProxyIP)
-			r.logger.Debugf("Delete ep %v %v", endpoint2, result)
-		}
-
-		if r.getClientCount(serverEp) == 0 {
-			if isOnSameNode {
-				stream, result := clientDpGrpcClient.DeleteStream(rtspStream.streamID, serverEp, 8050)
-				r.rtspStream.Delete(serverEp)
-				r.logger.Debugf("Delete stream %v %v", stream, result)
-			} else {
-				stream, result := serverDpGrpcClient.DeleteStream(rtspStream.streamID, serverEp, 8050)
-				r.rtspStream.Delete(serverEp)
-				r.logger.Debugf("Delete stream %v %v", stream, result)
-
-				stream2, result := clientDpGrpcClient.DeleteStream(rtspStream.streamID, serverProxyIP, 8050)
-				r.logger.Debugf("Delete stream %v %v", stream2, result)
-			}
-
-		}
-	}
-
-	clientDpGrpcClient.Close()
-	if !isOnSameNode {
-		serverDpGrpcClient.Close()
-	}
-
-	return nil
+	return &streamData
 }

--- a/internal/stub/stub_handler.go
+++ b/internal/stub/stub_handler.go
@@ -1,0 +1,255 @@
+package stub
+
+import (
+	"fmt"
+	pb "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_cp"
+	"github.com/media-streaming-mesh/msm-cp/internal/config"
+	"github.com/media-streaming-mesh/msm-cp/internal/model"
+	"github.com/media-streaming-mesh/msm-cp/internal/rtm"
+	"github.com/media-streaming-mesh/msm-cp/internal/util"
+	node_mapper "github.com/media-streaming-mesh/msm-cp/pkg/node-mapper"
+	stream_mapper "github.com/media-streaming-mesh/msm-cp/pkg/stream-mapper"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/peer"
+	"io"
+	"net"
+	"sync"
+)
+
+// API provides external access to stub
+type StubAPI interface {
+	Send(conn pb.MsmControlPlane_SendServer) error
+}
+
+type StubHandler struct {
+	logger  *logrus.Logger
+	rtmImpl rtm.API
+
+	//TODO: move stream_mapper to msm-nc
+	streamMapper *stream_mapper.StreamMapper
+}
+
+func NewStubHandler(cfg *config.Cfg) *StubHandler {
+	model.StubMap = new(sync.Map)
+	protocol := rtm.New(cfg)
+
+	return &StubHandler{
+		logger:       cfg.Logger,
+		rtmImpl:      protocol,
+		streamMapper: stream_mapper.NewStreamMapper(cfg.Logger, new(sync.Map)),
+	}
+}
+
+func (s *StubHandler) log(format string, args ...interface{}) {
+	// keep remote address outside format, since it can contain %
+	s.logger.Debugf("[Stub Handler] " + fmt.Sprintf(format, args...))
+}
+
+func (s *StubHandler) Send(conn pb.MsmControlPlane_SendServer) error {
+	var ctx = conn.Context()
+	for {
+		// exit if context is done or continue
+		select {
+		case <-ctx.Done():
+			s.log("reveiced connection done")
+			return ctx.Err()
+		default:
+		}
+
+		//Process stream data
+		stream, err := conn.Recv()
+		if err == io.EOF {
+			// return will close stream-mapper from server side
+			s.log("found EOF, exiting")
+			return nil
+		}
+		if err != nil {
+			s.log("received error %v", err)
+			continue
+		}
+
+		switch stream.Event {
+		case pb.Event_REGISTER:
+			s.log("Received REGISTER event: %v", stream)
+			s.OnRegistration(conn)
+
+		case pb.Event_ADD:
+			s.log("Received ADD event: %v", stream)
+			s.OnAdd(conn, stream)
+
+		case pb.Event_DELETE:
+			s.log("Received DELETE event: %v", stream)
+			s.OnDelete(conn, stream)
+
+		case pb.Event_DATA:
+			s.log("Received DATA event: %v", stream)
+			s.OnData(conn, stream)
+		default:
+		}
+	}
+}
+
+// Call when receive REGISTRATION event
+func (s *StubHandler) OnRegistration(conn pb.MsmControlPlane_SendServer) {
+
+	// get remote ip addr
+	ctx := conn.Context()
+	p, _ := peer.FromContext(ctx)
+	remoteAddr, _, _ := net.SplitHostPort(p.Addr.String())
+
+	sc := model.NewStubConnection(remoteAddr, conn)
+
+	//Send node ip address to stub
+	dataplaneIP, err := node_mapper.MapNode(remoteAddr)
+	s.log("Send msm-proxy ip %v:8050 to %v", dataplaneIP, remoteAddr)
+	if err == nil {
+		configMsg := &pb.Message{
+			Event:  pb.Event_CONFIG,
+			Remote: fmt.Sprintf("%s:8050", dataplaneIP),
+		}
+		sc.Conn.Send(configMsg)
+	}
+
+	// save stub connection on a sync.Map
+	model.StubMap.Store(remoteAddr, sc)
+	s.log("Connection for client: %s successfully registered", remoteAddr)
+}
+
+// Call when receive ADD event
+func (s *StubHandler) OnAdd(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
+
+	//Stub send to add channel
+	stubAddr := util.GetRemoteIPv4Address(stream.Remote)
+	sc, ok := model.StubMap.Load(stubAddr)
+	if ok {
+		//Add RTSP connection
+		s.rtmImpl.OnAdd(stream)
+
+		sc.(*model.StubConnection).Data = *stream
+		sc.(*model.StubConnection).AddCh <- stream
+		sc.(*model.StubConnection).SendToAddCh = true
+		s.log("StubConnection send %v to add channel", stream)
+	} else {
+		s.OnAddExternalClient(conn, stream)
+	}
+}
+
+func (s *StubHandler) OnAddExternalClient(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
+	// get remote ip addr
+	ctx := conn.Context()
+	p, _ := peer.FromContext(ctx)
+	stubAddr, _, _ := net.SplitHostPort(p.Addr.String())
+	remoteAddr := util.GetRemoteIPv4Address(stream.Remote)
+
+	sc, ok := model.StubMap.Load(stubAddr)
+	if !ok {
+		s.logger.Errorf("[Stub Handler] Gateway stub connection was not found! %v", stubAddr)
+		return
+	}
+
+	//Add RTSP connection
+	s.rtmImpl.OnAddExternalClient(stream, sc.(*model.StubConnection).Data)
+
+	//Add clients to stub
+	sc.(*model.StubConnection).Clients[stream.Remote] = remoteAddr
+	s.log("Save client %v with key %v to stub %v", remoteAddr, stream.Remote, stubAddr)
+}
+
+// Call when receive DELETE event
+func (s *StubHandler) OnDelete(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
+	//Delete RTSP connection
+	streamData := s.rtmImpl.OnDelete(stream)
+
+	//Stub unblock add chanel
+	stubAddr := util.GetRemoteIPv4Address(stream.Remote)
+	sc, ok := model.StubMap.Load(stubAddr)
+	if ok {
+		if sc.(*model.StubConnection).SendToAddCh {
+			<-sc.(*model.StubConnection).AddCh
+			sc.(*model.StubConnection).SendToAddCh = false
+		}
+	} else {
+		s.OnDeleteExternalClient(conn, stream)
+	}
+
+	//Send delete to proxy
+	s.log("Stream data %v", streamData)
+	if streamData != nil {
+		stubAddress := s.getStubAddress(streamData.ClientIp)
+		s.log("StubAddress %v", stubAddress)
+
+		//TODO: add stub address to stream data and send to stream mapper
+		error := s.streamMapper.ProcessStream(model.StreamData{
+			StubIp:      stubAddress,
+			ServerIp:    streamData.ServerIp,
+			ClientIp:    streamData.ClientIp,
+			ServerPorts: streamData.ServerPorts,
+			ClientPorts: streamData.ClientPorts,
+			StreamState: streamData.StreamState,
+		})
+
+		if error != nil {
+			s.log("ProcessStream failed %v", error)
+		}
+	}
+}
+
+func (s *StubHandler) OnDeleteExternalClient(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
+	// get remote ip addr
+	ctx := conn.Context()
+	p, _ := peer.FromContext(ctx)
+	stubAddr, _, _ := net.SplitHostPort(p.Addr.String())
+	remoteAddr := util.GetRemoteIPv4Address(stream.Remote)
+
+	sc, ok := model.StubMap.Load(stubAddr)
+	if !ok {
+		s.logger.Errorf("[Stub Handler] Gateway stub connection was not found! %v", stubAddr)
+		return
+	}
+	delete(sc.(*model.StubConnection).Clients, stream.Remote)
+	s.log("Connection for external client: %s successfully close", remoteAddr)
+	s.log("Delete client %v with key %v from stub %v", remoteAddr, stream.Remote, stubAddr)
+}
+
+// Call when receive DATA event
+func (s *StubHandler) OnData(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
+	//Process RTSP connection
+	streamData := s.rtmImpl.OnData(conn, stream)
+
+	s.log("Stream  %v", stream)
+	s.log("Stream data %v", streamData)
+
+	if streamData != nil {
+		stubAddress := s.getStubAddress(streamData.ClientIp)
+		s.log("StubAddress %v", stubAddress)
+
+		//TODO: add stub address to stream data and send to stream mapper
+		error := s.streamMapper.ProcessStream(model.StreamData{
+			StubIp:      stubAddress,
+			ServerIp:    streamData.ServerIp,
+			ClientIp:    streamData.ClientIp,
+			ServerPorts: streamData.ServerPorts,
+			ClientPorts: streamData.ClientPorts,
+			StreamState: streamData.StreamState,
+		})
+
+		if error != nil {
+			s.log("ProcessStream failed %v", error)
+		}
+	}
+}
+
+func (s *StubHandler) getStubAddress(clientAddress string) string {
+	var stubAddress = ""
+	model.StubMap.Range(func(key, value interface{}) bool {
+		stub := value.(*model.StubConnection)
+		for _, address := range stub.Clients {
+			if address == clientAddress {
+				stubAddress = key.(string)
+				break
+			}
+		}
+		return true
+	})
+	return stubAddress
+}

--- a/internal/stub/stub_handler.go
+++ b/internal/stub/stub_handler.go
@@ -2,107 +2,88 @@ package stub
 
 import (
 	"fmt"
+	"github.com/aler9/gortsplib/pkg/base"
 	pb "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_cp"
 	"github.com/media-streaming-mesh/msm-cp/internal/config"
-	"github.com/media-streaming-mesh/msm-cp/internal/model"
-	"github.com/media-streaming-mesh/msm-cp/internal/rtm"
 	"github.com/media-streaming-mesh/msm-cp/internal/util"
 	node_mapper "github.com/media-streaming-mesh/msm-cp/pkg/node-mapper"
-	stream_mapper "github.com/media-streaming-mesh/msm-cp/pkg/stream-mapper"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/peer"
-	"io"
 	"net"
 	"sync"
 )
 
-// API provides external access to stub
-type StubAPI interface {
-	Send(conn pb.MsmControlPlane_SendServer) error
+var (
+	StubMap *sync.Map
+)
+
+type StubConnection struct {
+	Address     string
+	Conn        pb.MsmControlPlane_SendServer
+	Data        pb.Message
+	SendToAddCh bool
+	AddCh       chan *pb.Message
+	DataCh      chan *base.Response
+	Clients     map[string]Client
+}
+
+func NewStubConnection(address string, conn pb.MsmControlPlane_SendServer) *StubConnection {
+	return &StubConnection{
+		Address: address,
+		Conn:    conn,
+		AddCh:   make(chan *pb.Message, 1),
+		DataCh:  make(chan *base.Response, 1),
+		Clients: make(map[string]Client),
+	}
+}
+
+type Client struct {
+	ClientId string
+	ClientIp string
+	Port     uint32
 }
 
 type StubHandler struct {
-	logger  *logrus.Logger
-	rtmImpl rtm.API
-
-	//TODO: move stream_mapper to msm-nc
-	streamMapper *stream_mapper.StreamMapper
+	logger *logrus.Logger
 }
 
 func NewStubHandler(cfg *config.Cfg) *StubHandler {
-	model.StubMap = new(sync.Map)
-	protocol := rtm.New(cfg)
+	StubMap = new(sync.Map)
 
 	return &StubHandler{
-		logger:       cfg.Logger,
-		rtmImpl:      protocol,
-		streamMapper: stream_mapper.NewStreamMapper(cfg.Logger, new(sync.Map)),
+		logger: cfg.Logger,
 	}
 }
 
 func (s *StubHandler) log(format string, args ...interface{}) {
-	// keep remote address outside format, since it can contain %
 	s.logger.Infof("[Stub Handler] " + fmt.Sprintf(format, args...))
 }
 
 func (s *StubHandler) logError(format string, args ...interface{}) {
-	// keep remote address outside format, since it can contain %
 	s.logger.Errorf("[Stub Handler] " + fmt.Sprintf(format, args...))
 }
 
-func (s *StubHandler) Send(conn pb.MsmControlPlane_SendServer) error {
-	var ctx = conn.Context()
-	for {
-		// exit if context is done or continue
-		select {
-		case <-ctx.Done():
-			s.log("received connection done")
-			return ctx.Err()
-		default:
-		}
-
-		//Process stream data
-		stream, err := conn.Recv()
-		if err == io.EOF {
-			// return will close stream-mapper from server side
-			s.logError("found EOF, exiting")
-			return nil
-		}
-		if err != nil {
-			s.logError("received error %v", err)
-			continue
-		}
-
-		switch stream.Event {
-		case pb.Event_REGISTER:
-			s.log("Received REGISTER event: %v", stream)
-			s.OnRegistration(conn)
-
-		case pb.Event_ADD:
-			s.log("Received ADD event: %v", stream)
-			s.OnAdd(conn, stream)
-
-		case pb.Event_DELETE:
-			s.log("Received DELETE event: %v", stream)
-			s.OnDelete(conn, stream)
-
-		case pb.Event_DATA:
-			s.log("Received DATA event: %v", stream)
-			s.OnData(conn, stream)
-		default:
-		}
+func (s *StubHandler) Send(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
+	switch stream.Event {
+	case pb.Event_REGISTER:
+		s.onRegistration(conn)
+	case pb.Event_ADD:
+		s.onAdd(conn, stream)
+	case pb.Event_DELETE:
+		s.onDelete(conn, stream)
+	default:
 	}
 }
 
 // Call when receive REGISTRATION event
-func (s *StubHandler) OnRegistration(conn pb.MsmControlPlane_SendServer) {
+func (s *StubHandler) onRegistration(conn pb.MsmControlPlane_SendServer) {
 
 	// get remote ip addr
 	ctx := conn.Context()
 	p, _ := peer.FromContext(ctx)
 	remoteAddr, _, _ := net.SplitHostPort(p.Addr.String())
 
-	sc := model.NewStubConnection(remoteAddr, conn)
+	sc := NewStubConnection(remoteAddr, conn)
 
 	//Send node ip address to stub
 	dataplaneIP, err := node_mapper.MapNode(remoteAddr)
@@ -116,47 +97,41 @@ func (s *StubHandler) OnRegistration(conn pb.MsmControlPlane_SendServer) {
 	}
 
 	// save stub connection on a sync.Map
-	model.StubMap.Store(remoteAddr, sc)
+	StubMap.Store(remoteAddr, sc)
 	s.log("Connection for client: %s successfully registered", remoteAddr)
 }
 
 // Call when receive ADD event
-func (s *StubHandler) OnAdd(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
+func (s *StubHandler) onAdd(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
 
 	//Stub send to add channel
 	stubAddr := util.GetRemoteIPv4Address(stream.Remote)
-	sc, ok := model.StubMap.Load(stubAddr)
+	sc, ok := StubMap.Load(stubAddr)
 	if ok {
-		//Add RTSP connection
-		s.rtmImpl.OnAdd(stream)
-
-		sc.(*model.StubConnection).Data = *stream
-		sc.(*model.StubConnection).AddCh <- stream
-		sc.(*model.StubConnection).SendToAddCh = true
+		sc.(*StubConnection).Data = *stream
+		sc.(*StubConnection).AddCh <- stream
+		sc.(*StubConnection).SendToAddCh = true
 		s.log("StubConnection send %v to add channel", stream)
 	} else {
-		s.OnAddExternalClient(conn, stream)
+		s.onAddExternalClient(conn, stream)
 	}
 }
 
-func (s *StubHandler) OnAddExternalClient(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
+func (s *StubHandler) onAddExternalClient(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
 	// get remote ip addr
 	ctx := conn.Context()
 	p, _ := peer.FromContext(ctx)
 	stubAddr, _, _ := net.SplitHostPort(p.Addr.String())
 	remoteAddr := util.GetRemoteIPv4Address(stream.Remote)
 
-	sc, ok := model.StubMap.Load(stubAddr)
+	sc, ok := StubMap.Load(stubAddr)
 	if !ok {
-		s.logger.Errorf("[Stub Handler] Gateway stub connection was not found! %v", stubAddr)
+		s.logError("Gateway stub connection was not found! %v", stubAddr)
 		return
 	}
 
-	//Add RTSP connection
-	s.rtmImpl.OnAddExternalClient(stream, sc.(*model.StubConnection).Data)
-
 	//Add clients to stub
-	sc.(*model.StubConnection).Clients[stream.Remote] = model.Client{
+	sc.(*StubConnection).Clients[stream.Remote] = Client{
 		stream.Remote,
 		remoteAddr,
 		0,
@@ -165,88 +140,41 @@ func (s *StubHandler) OnAddExternalClient(conn pb.MsmControlPlane_SendServer, st
 }
 
 // Call when receive DELETE event
-func (s *StubHandler) OnDelete(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
-	//Delete RTSP connection
-	streamData := s.rtmImpl.OnDelete(stream)
-
+func (s *StubHandler) onDelete(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
 	//Stub unblock add chanel
 	stubAddr := util.GetRemoteIPv4Address(stream.Remote)
-	sc, ok := model.StubMap.Load(stubAddr)
+	sc, ok := StubMap.Load(stubAddr)
 	if ok {
-		if sc.(*model.StubConnection).SendToAddCh {
-			<-sc.(*model.StubConnection).AddCh
-			sc.(*model.StubConnection).SendToAddCh = false
+		if sc.(*StubConnection).SendToAddCh {
+			<-sc.(*StubConnection).AddCh
+			sc.(*StubConnection).SendToAddCh = false
 		}
 	} else {
-		s.OnDeleteExternalClient(conn, stream)
-	}
-
-	//Send delete to proxy
-	if streamData != nil {
-		stubAddress := s.getStubAddress(streamData.ClientIp, stream.Remote)
-
-		//TODO: add stub address to stream data and send to stream mapper
-		_ = s.streamMapper.ProcessStream(model.StreamData{
-			StubIp:      stubAddress,
-			ServerIp:    streamData.ServerIp,
-			ClientIp:    streamData.ClientIp,
-			ServerPorts: streamData.ServerPorts,
-			ClientPorts: streamData.ClientPorts,
-			StreamState: streamData.StreamState,
-		})
-
-		//if error != nil {
-		//	s.logError("ProcessStream failed %v", error)
-		//}
+		s.onDeleteExternalClient(conn, stream)
 	}
 }
 
-func (s *StubHandler) OnDeleteExternalClient(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
+func (s *StubHandler) onDeleteExternalClient(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
 	// get remote ip addr
 	ctx := conn.Context()
 	p, _ := peer.FromContext(ctx)
 	stubAddr, _, _ := net.SplitHostPort(p.Addr.String())
 	remoteAddr := util.GetRemoteIPv4Address(stream.Remote)
 
-	sc, ok := model.StubMap.Load(stubAddr)
+	sc, ok := StubMap.Load(stubAddr)
 	if !ok {
 		s.logError("Gateway stub connection was not found! %v", stubAddr)
 		return
 	}
-	delete(sc.(*model.StubConnection).Clients, stream.Remote)
+	delete(sc.(*StubConnection).Clients, stream.Remote)
 	s.log("Connection for external client: %s successfully close", remoteAddr)
 	s.log("Delete client %v with key %v from stub %v", remoteAddr, stream.Remote, stubAddr)
 }
 
-// Call when receive DATA event
-func (s *StubHandler) OnData(conn pb.MsmControlPlane_SendServer, stream *pb.Message) {
-	//Process RTSP connection
-	streamData := s.rtmImpl.OnData(conn, stream)
-
-	if streamData != nil {
-		stubAddress := s.getStubAddress(streamData.ClientIp, stream.Remote)
-		s.log("StubAddress %v", stubAddress)
-
-		//TODO: add stub address to stream data and send to stream mapper
-		error := s.streamMapper.ProcessStream(model.StreamData{
-			StubIp:      stubAddress,
-			ServerIp:    streamData.ServerIp,
-			ClientIp:    streamData.ClientIp,
-			ServerPorts: streamData.ServerPorts,
-			ClientPorts: streamData.ClientPorts,
-			StreamState: streamData.StreamState,
-		})
-
-		if error != nil {
-			s.logError("ProcessStream failed %v", error)
-		}
-	}
-}
-
-func (s *StubHandler) getStubAddress(clientIp string, clientId string) string {
+func GetStubAddress(clientIp string, clientId string) string {
 	var stubAddress = clientIp
-	model.StubMap.Range(func(key, value interface{}) bool {
-		stub := value.(*model.StubConnection)
+	StubMap.Range(func(key, value interface{}) bool {
+		stub := value.(*StubConnection)
 		for _, c := range stub.Clients {
 			if c.ClientIp == clientIp && c.ClientId == clientId {
 				stubAddress = key.(string)

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -4,28 +4,7 @@ import (
 	"context"
 	pb "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_dp"
 	"github.com/sirupsen/logrus"
-	"sync"
 )
-
-var streamId StreamId
-
-// Stream id type uint32 auto increment
-type StreamId struct {
-	sync.Mutex
-	id uint32
-}
-
-func (si *StreamId) ID() (id uint32) {
-	si.Lock()
-	defer si.Unlock()
-	id = si.id
-	si.id++
-	return
-}
-
-func GetStreamID() uint32 {
-	return streamId.ID()
-}
 
 // Client holds the client specific data structures
 type Client struct {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,19 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+func GetRemoteIPv4Address(url string) string {
+	res := strings.ReplaceAll(url, "[", "")
+	res = strings.ReplaceAll(res, "]", "")
+	n := strings.LastIndex(res, ":")
+
+	return fmt.Sprintf("%s", net.ParseIP(res[:n]))
+}
+
+func GetConnectionKey(s1, s2 string) string {
+	return fmt.Sprintf("%s%s", s1, s2)
+}

--- a/pkg/stream-mapper/stream_mapper.go
+++ b/pkg/stream-mapper/stream_mapper.go
@@ -1,0 +1,271 @@
+package stream_mapper
+
+import (
+	"errors"
+	"fmt"
+	pb_dp "github.com/media-streaming-mesh/msm-cp/api/v1alpha1/msm_dp"
+	"github.com/media-streaming-mesh/msm-cp/internal/model"
+	"github.com/media-streaming-mesh/msm-cp/internal/transport"
+	node_mapper "github.com/media-streaming-mesh/msm-cp/pkg/node-mapper"
+	"github.com/sirupsen/logrus"
+	"sync"
+)
+
+type StreamMapper struct {
+	logger    *logrus.Logger
+	streamMap *sync.Map
+}
+
+func NewStreamMapper(logger *logrus.Logger, streamMap *sync.Map) *StreamMapper {
+	return &StreamMapper{
+		logger:    logger,
+		streamMap: streamMap,
+	}
+}
+
+func (m *StreamMapper) log(format string, args ...interface{}) {
+	// keep remote address outside format, since it can contain %
+	m.logger.Debugf("[Stream Mapper] " + fmt.Sprintf(format, args...))
+}
+
+func (m *StreamMapper) ProcessStream(data model.StreamData) error {
+	var serverProxyIP string
+	var clientProxyIP string
+	var serverDpGrpcClient transport.Client
+	var clientDpGrpcClient transport.Client
+
+	m.log("Processing stream %v", data)
+
+	if len(data.ServerPorts) == 0 || len(data.ClientPorts) == 0 {
+		return errors.New("[Stream Mapper] empty server/client port")
+	}
+
+	//Check if client/server on same node
+	clientIp := data.StubIp
+	if clientIp == "" {
+		clientIp = data.ClientIp
+	}
+	isOnSameNode := node_mapper.IsOnSameNode(clientIp, data.ServerIp)
+	m.log("server %v and client %v - same node is %v", data.ServerIp, clientIp, isOnSameNode)
+
+	//Get proxy ip
+	clientProxyIP, err := node_mapper.MapNode(clientIp)
+	if err != nil {
+		return err
+	}
+	m.log("client msm-proxy ip %v", clientProxyIP)
+	if !isOnSameNode {
+		serverProxyIP, err = node_mapper.MapNode(data.ServerIp)
+		if err != nil {
+			return err
+		}
+		m.log("server msm-proxy ip %v", serverProxyIP)
+	}
+
+	//Create GRPC connection
+	clientGrpcClient, err := transport.SetupClient(clientProxyIP)
+	if err != nil {
+		m.log("Failed to setup GRPC client, error %s\n", err)
+	}
+	clientDpGrpcClient = transport.Client{
+		m.logger,
+		clientGrpcClient,
+	}
+
+	if !isOnSameNode {
+		serverGrpcClient, err := transport.SetupClient(serverProxyIP)
+		if err != nil {
+			m.log("Failed to setup GRPC client, error %s\n", err)
+		}
+		serverDpGrpcClient = transport.Client{
+			m.logger,
+			serverGrpcClient,
+		}
+	}
+
+	//Send data to proxy
+	if data.StreamState == model.Create {
+		var stream model.Stream
+		savedStream, _ := m.streamMap.Load(data.ServerIp)
+
+		//Send Create Stream to proxy
+		if savedStream == nil {
+			streamId := model.GetStreamID()
+			m.log("stream Id %v", streamId)
+
+			//Create new stream
+			stream = model.Stream{
+				StreamId: streamId,
+				ProxyMap: make(map[string]model.Proxy),
+			}
+
+			if isOnSameNode {
+				// add the stream-mapper to the proxy
+				streamData, result := clientDpGrpcClient.CreateStream(streamId, pb_dp.Encap_RTP_UDP, data.ServerIp, data.ServerPorts[0])
+				m.log("Create stream %v result %v", streamData, *result)
+			} else {
+				// add the stream-mapper to the server proxy
+				streamData, result := serverDpGrpcClient.CreateStream(streamId, pb_dp.Encap_RTP_UDP, data.ServerIp, data.ServerPorts[0])
+				m.log("Create server stream %v result %v", streamData, *result)
+
+				// add the stream-mapper to the client proxy
+				streamData, result = clientDpGrpcClient.CreateStream(streamId, pb_dp.Encap_RTP_UDP, serverProxyIP, data.ServerPorts[0])
+				m.log("Create client stream %v result %v", streamData, *result)
+
+				// add the server proxy to the proxy map
+				stream.ProxyMap[serverProxyIP] = model.Proxy{
+					ProxyIp:     serverProxyIP,
+					StreamState: model.Create,
+				}
+			}
+
+			// add the client proxy to the proxy map
+			stream.ProxyMap[clientProxyIP] = model.Proxy{
+				ProxyIp:     clientProxyIP,
+				StreamState: model.Create,
+			}
+
+			// now store the RTSP stream-mapper
+			m.streamMap.Store(data.ServerIp, stream)
+
+		} else {
+			stream = savedStream.(model.Stream)
+			if _, exists := stream.ProxyMap[clientProxyIP]; !exists {
+				// add the stream-mapper to the client proxy
+				streamData, result := clientDpGrpcClient.CreateStream(stream.StreamId, pb_dp.Encap_RTP_UDP, serverProxyIP, data.ServerPorts[0])
+				m.log("Create client stream %v result %v", streamData, *result)
+
+				// add the client proxy to the proxy map
+				stream.ProxyMap[clientProxyIP] = model.Proxy{
+					ProxyIp:     clientProxyIP,
+					StreamState: model.Create,
+				}
+			}
+		}
+
+		//Send Create Endpoint to proxy
+		clientProxy := stream.ProxyMap[clientProxyIP]
+		m.log("Client proxy %v total clients %v", clientProxy, len(clientProxy.Clients))
+
+		if !isOnSameNode && clientProxy.StreamState < model.Play {
+			endpoint, result := serverDpGrpcClient.CreateEndpoint(stream.StreamId, pb_dp.Encap_RTP_UDP, clientProxyIP, 8050)
+			m.log("Created proxy-proxy ep %v result %v", endpoint, *result)
+		}
+
+		endpoint, result := clientDpGrpcClient.CreateEndpoint(stream.StreamId, pb_dp.Encap_RTP_UDP, data.ClientIp, data.ClientPorts[0])
+		m.log("Create client ep %v result %v", endpoint, result)
+
+		//Update streamMap data
+		clientProxy.Clients = append(clientProxy.Clients, model.Client{
+			ClientIp: data.ClientIp,
+			Port:     data.ClientPorts[0],
+		})
+		stream.ProxyMap[clientProxyIP] = model.Proxy{
+			ProxyIp:     clientProxyIP,
+			StreamState: clientProxy.StreamState,
+			Clients:     clientProxy.Clients,
+		}
+		m.log("Stream %v", stream)
+	}
+
+	if data.StreamState == model.Play {
+		savedStream, _ := m.streamMap.Load(data.ServerIp)
+		if savedStream == nil {
+			return errors.New("[Stream Mapper] Can't find stream")
+		}
+
+		stream := savedStream.(model.Stream)
+		clientProxy, exists := stream.ProxyMap[clientProxyIP]
+		if !exists {
+			return errors.New("[Stream Mapper] Can't find client proxy")
+		}
+		m.log("Client proxy PLAY %v proxy clients %v total clients %v", clientProxy, len(clientProxy.Clients))
+		for _, c := range clientProxy.Clients {
+			if c.ClientIp == data.ClientIp && c.Port == data.ClientPorts[0] {
+				endpoint, result := clientDpGrpcClient.UpdateEndpoint(stream.StreamId, data.ClientIp, data.ClientPorts[0])
+				m.log("Update ep %v result %v", endpoint, result)
+
+				if !isOnSameNode && clientProxy.StreamState < model.Play {
+					endpoint2, result := serverDpGrpcClient.UpdateEndpoint(stream.StreamId, clientProxyIP, 8050)
+					stream.ProxyMap[clientProxyIP] = model.Proxy{
+						ProxyIp:     clientProxy.ProxyIp,
+						StreamState: model.Play,
+						Clients:     clientProxy.Clients,
+					}
+					m.log("Update proxy ep %v result %v", endpoint2, result)
+				}
+				break
+			}
+		}
+	}
+
+	if data.StreamState == model.Teardown {
+		savedStream, _ := m.streamMap.Load(data.ServerIp)
+		if savedStream == nil {
+			return errors.New("[Stream Mapper] Can't find stream")
+		}
+
+		stream := savedStream.(model.Stream)
+		clientProxy, exists := stream.ProxyMap[clientProxyIP]
+		if !exists {
+			return errors.New("[Stream Mapper] Can't find client proxy")
+		}
+		m.log("Client proxy TEARDOWN %v proxy clients %v total clients %v", clientProxy, len(clientProxy.Clients), m.getClientCount(data.ServerIp))
+
+		for i, c := range clientProxy.Clients {
+			if c.ClientIp == data.ClientIp && c.Port == data.ClientPorts[0] {
+				endpoint, result := clientDpGrpcClient.DeleteEndpoint(stream.StreamId, data.ClientIp, data.ClientPorts[0])
+				m.log("Delete ep %v %v", endpoint, result)
+				clientProxy.Clients = append(clientProxy.Clients[:i], clientProxy.Clients[i+1:]...)
+				break
+			}
+		}
+
+		stream.ProxyMap[clientProxyIP] = model.Proxy{
+			ProxyIp:     clientProxy.ProxyIp,
+			StreamState: clientProxy.StreamState,
+			Clients:     clientProxy.Clients,
+		}
+
+		//End proxy-proxy connection
+		if !isOnSameNode && clientProxy.StreamState < model.Teardown && len(clientProxy.Clients) == 0 {
+			endpoint2, result := serverDpGrpcClient.DeleteEndpoint(stream.StreamId, clientProxyIP, 8050)
+			delete(stream.ProxyMap, clientProxyIP)
+			m.log("Delete ep %v %v", endpoint2, result)
+		}
+
+		//Delete stream if all clients terminate
+		if m.getClientCount(data.ServerIp) == 0 {
+			if isOnSameNode {
+				streamData, result := clientDpGrpcClient.DeleteStream(stream.StreamId, data.ServerIp, 8050)
+				m.streamMap.Delete(data.ServerIp)
+				m.log("Delete stream-mapper %v %v", streamData, result)
+			} else {
+				streamData, result := serverDpGrpcClient.DeleteStream(stream.StreamId, data.ServerIp, 8050)
+				m.streamMap.Delete(data.ServerIp)
+				m.log("Delete stream-mapper %v %v", streamData, result)
+
+				streamData2, result := clientDpGrpcClient.DeleteStream(stream.StreamId, serverProxyIP, 8050)
+				m.log("Delete stream-mapper %v %v", streamData2, result)
+			}
+
+		}
+	}
+
+	clientDpGrpcClient.Close()
+	if !isOnSameNode {
+		serverDpGrpcClient.Close()
+	}
+	return nil
+}
+
+func (m *StreamMapper) getClientCount(serverEp string) int {
+	count := 0
+	data, _ := m.streamMap.Load(serverEp)
+	if data != nil {
+		for _, v := range data.(model.Stream).ProxyMap {
+			count += len(v.Clients)
+		}
+	}
+	return count
+}

--- a/pkg/stream-mapper/stream_mapper.go
+++ b/pkg/stream-mapper/stream_mapper.go
@@ -179,7 +179,7 @@ func (m *StreamMapper) ProcessStream(data model.StreamData) error {
 		if !exists {
 			return errors.New("[Stream Mapper] Can't find client proxy")
 		}
-		m.log("Client proxy PLAY %v proxy clients %v total clients %v", clientProxy, len(clientProxy.Clients))
+		m.log("Client proxy PLAY proxy clients %v total clients %v", clientProxy, len(clientProxy.Clients))
 		for _, c := range clientProxy.Clients {
 			if c.ClientIp == data.ClientIp && c.Port == data.ClientPorts[0] {
 				endpoint, result := clientDpGrpcClient.UpdateEndpoint(stream.StreamId, data.ClientIp, data.ClientPorts[0])

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -23,5 +23,5 @@ func TestCreateStream(t *testing.T) {
 	}
 
 	stream, result := dpGrpcClient.CreateStream("192.168.82.20", 8050)
-	logger.Debugf("Create stream %v %v", stream, result)
+	logger.Debugf("Create stream-mapper %v %v", stream, result)
 }


### PR DESCRIPTION
- Refactor MSM minimal setup:
- Please refer to slide 19 for architecture
- Separate logics: RTSP, stub, stream map
- Protocol Plugin is protocol.go, Stream Mapper is stream_mapper.go, CP SB is stub_handler.go
- Data structure:
  - rtspConn is a syncMap that contains all RTSP connection for server/client
  - StubMap is a syncMap that contains stub connection. Each connection has a list of clients to keep track of external clients.
  - streamMap is a syncMap that keep track of stream from server to proxy. Each stream has streamId and proxy object with has proxyId, streamState and list of clients. 
- Currently ProtocolPlugin send data to stream mapper by call a function on stream mapper. This would replace with update data on etcd datastore 

Next refactor:
- Separate into two services
- Create etcd datastore
- Define logical stream graph. Currently just pass data that contains StubIp, ServerIp, ClientIp, ServerPorts, ClientPorts, and StreamState. Stream mapper would process those data into stream map. 